### PR TITLE
refactor: migrate to shared html utils and add secret validation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { fetchWithTimeout } from './shared/fetch-helpers.js';
+import { escapeHtml, sanitizeParam } from './shared/html.js';
 
 // ================================================================
 // department-news-display — Cloudflare Worker
@@ -203,6 +204,22 @@ export default {
       ? layoutParam.toLowerCase()
       : 'split';
 
+    var REQUIRED_SECRETS = [
+      'GOOGLE_SERVICE_ACCOUNT_EMAIL',
+      'GOOGLE_PRIVATE_KEY',
+      'GOOGLE_SHEET_ID'
+    ];
+    for (var i = 0; i < REQUIRED_SECRETS.length; i++) {
+      var key = REQUIRED_SECRETS[i];
+      if (!env[key]) {
+        console.error('[department-news-display] Missing required secret: ' + key);
+        return new Response(
+          'Configuration error: missing secret ' + key,
+          { status: 500, headers: { 'Content-Type': 'text/plain' } }
+        );
+      }
+    }
+
     try {
       // Authenticate with Google and fetch sheet data.
       const token = await getAccessToken(
@@ -393,19 +410,6 @@ function arrayBufferToBase64url(buffer) {
     .replace(/\//g, '_')
     .replace(/=/g,  '');
 }
-
-/**
- * Strips leading/trailing whitespace from a URL parameter value and
- * removes any characters that are not alphanumeric, hyphens, or underscores.
- * Returns null if the input is null.
- * @param {string|null} val
- * @returns {string|null}
- */
-function sanitizeParam(val) {
-  if (val === null) return null;
-  return val.trim().replace(/[^a-zA-Z0-9\-_#]/g, '');
-}
-
 
 // ================================================================
 // SHEET DATA FETCHING
@@ -668,21 +672,6 @@ function formatDateTime(date) {
 }
 
 /**
- * Escapes characters with special meaning in HTML to prevent XSS.
- * Must be called on every user-supplied string before HTML injection.
- * @param {string} str
- * @returns {string}
- */
-function escapeHtml(str) {
-  return String(str)
-    .replace(/&/g,  '&amp;')
-    .replace(/</g,  '&lt;')
-    .replace(/>/g,  '&gt;')
-    .replace(/"/g,  '&quot;')
-    .replace(/'/g,  '&#39;');
-}
-
-/**
  * Renders the complete HTML page for the news display.
  * Scroll constants are injected as inline JS variables so the
  * client-side scroll logic uses the server-side configuration values.
@@ -901,6 +890,19 @@ function renderHtml(items, layout, tabName, darkBg) {
  * @param {object} env
  */
 async function runCleanup(env) {
+  var REQUIRED_CLEANUP_SECRETS = [
+    'GOOGLE_SERVICE_ACCOUNT_EMAIL',
+    'GOOGLE_PRIVATE_KEY',
+    'GOOGLE_SHEET_ID'
+  ];
+  for (var ci = 0; ci < REQUIRED_CLEANUP_SECRETS.length; ci++) {
+    var ckey = REQUIRED_CLEANUP_SECRETS[ci];
+    if (!env[ckey]) {
+      console.error('[department-news-display] runCleanup: missing secret: ' + ckey);
+      return;
+    }
+  }
+
   const token       = await getAccessToken(
     env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
     env.GOOGLE_PRIVATE_KEY


### PR DESCRIPTION
## Summary

Three changes in `src/index.js`:

1. **Imports `escapeHtml` and `sanitizeParam` from `src/shared/html.js`** — removes local copies of both functions. Behavior unchanged.

2. **Adds required secret validation** at the top of both the main `fetch` handler and the `runCleanup` scheduled handler. Missing secrets now produce a clear error (HTTP 500 with plain-text body in the fetch handler; `console.error` + early return in `runCleanup`) rather than a cryptic downstream failure.

3. `fetchWithTimeout` import already present from Phase 3.

Part of Phase 4 + Phase 5 shared-utils migration.

## Audit issues

No open `priority-2` labeled issues found in this repository at time of PR creation.

## Test plan

- [ ] Confirm `escapeHtml` and `sanitizeParam` calls still resolve correctly (imported from shared module)
- [ ] Deploy to staging and verify normal page renders correctly
- [ ] Test with a missing secret (e.g. unset `GOOGLE_SHEET_ID` in staging) and confirm HTTP 500 with `Configuration error: missing secret GOOGLE_SHEET_ID`
- [ ] Confirm scheduled cleanup logs `runCleanup: missing secret` and returns early when a secret is absent

https://claude.ai/code/session_01LMSx7e3RruCd7DHXG7zL96