### PR TITLE
fix: use styled error page for secret validation errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -214,8 +214,34 @@ export default {
       if (!env[key]) {
         console.error('[department-news-display] Missing required secret: ' + key);
         return new Response(
-          'Configuration error: missing secret ' + key,
-          { status: 500, headers: { 'Content-Type': 'text/plain' } }
+          '<!DOCTYPE html>' +
+          '<html lang="en"><head><meta charset="UTF-8">' +
+          '<meta http-equiv="refresh" content="60">' +
+          '<style>' +
+          '*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}' +
+          'html,body{' +
+          '  width:100vw;height:100vh;overflow:hidden;' +
+          '  background:' + (darkBg ? DARK_BG_COLOR : 'transparent') + ';' +
+          '  font-family:"Segoe UI",Arial,Helvetica,sans-serif;' +
+          '  display:flex;align-items:center;justify-content:center;}' +
+          '.err-wrap{display:flex;flex-direction:column;align-items:center;' +
+          '  gap:8px;text-align:center;padding:0 5vw;}' +
+          '.err-title{font-size:1.8rem;font-weight:700;color:#C8102E;' +
+          '  letter-spacing:0.06em;}' +
+          '.err-sub{font-size:1.1rem;color:rgba(255,255,255,0.92);}' +
+          '</style></head><body>' +
+          '<div class="err-wrap">' +
+          '<div class="err-title">CONFIGURATION ERROR</div>' +
+          '<div class="err-sub">Missing secret: ' + key + '</div>' +
+          '</div></body></html>',
+          {
+            status: 500,
+            headers: {
+              'Content-Type':           'text/html; charset=UTF-8',
+              'Cache-Control':          'no-store',
+              'X-Content-Type-Options': 'nosniff',
+            },
+          }
         );
       }
     }


### PR DESCRIPTION
## Summary

- The secret validation block returned a plain `text/plain` Response, producing an unstyled error page inconsistent with the project design language.
- Replaced with a styled HTML error page matching the design used by all other error responses in this worker — dark background (respecting `?bg=dark`), FFD red title, white subtitle, auto-refresh every 60 seconds.
- `darkBg` and `layout` were already parsed before the validation block, so no reordering was needed.

## Verification

- `grep -n "text/plain"` → zero matches (plain text response removed)
- `grep -n "CONFIGURATION ERROR"` → found at line 234 (styled error page present)
- `grep -n "DARK_BG_COLOR"` → referenced at line 224 inside the new error response

## Test plan

- [ ] Deploy to a test worker with one or more secrets omitted; confirm a styled red-title error page renders instead of a plain text response
- [ ] Confirm `?bg=dark` applies the dark background to the error page
- [ ] Confirm the page auto-refreshes after 60 seconds

https://claude.ai/code/session_01KXXqP71wkroTQYu3641W2p