### PR TITLE
refactor: migrate to shared google-auth and constants

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import { fetchWithTimeout } from './shared/fetch-helpers.js';
 import { escapeHtml, sanitizeParam } from './shared/html.js';
+import { getAccessToken } from './shared/google-auth.js';
+import { DARK_BG_COLOR } from './shared/constants.js';
 
 // ================================================================
 // department-news-display — Cloudflare Worker
@@ -69,10 +71,6 @@ const FONT_SIZE_BODY = '1rem';
  *  as a title underline on regular items. */
 const ACCENT_COLOR = '#C8102E';
 
-/** Background color used when ?bg=dark is set.
- *  Matches the probationary-firefighter-display dark testing background. */
-const DARK_BG_COLOR = '#111111';
-
 // --- Card color configuration ---
 // Regular (non-new) items alternate between these two backgrounds.
 // Both are subtle dark tints to visually separate cards against
@@ -99,14 +97,6 @@ const COLOR_NEW_B = 'rgba(210,210,210,0.30)';
  *  deleted by the daily cron job.
  *  Set to -1 to disable automatic deletion entirely. */
 const DELETE_EXPIRED_AFTER_DAYS = 7;
-
-
-// ================================================================
-// GOOGLE AUTH SCOPE
-// spreadsheets scope is required for both read (display) and
-// write (row deletion) access to the sheet.
-// ================================================================
-const GOOGLE_AUTH_SCOPE = 'https://www.googleapis.com/auth/spreadsheets';
 
 
 // ================================================================
@@ -250,7 +240,8 @@ export default {
       // Authenticate with Google and fetch sheet data.
       const token = await getAccessToken(
         env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
-        env.GOOGLE_PRIVATE_KEY
+        env.GOOGLE_PRIVATE_KEY,
+        'https://www.googleapis.com/auth/spreadsheets'
       );
       const rows = await fetchSheetRows(env, token, tabName);
 
@@ -323,119 +314,6 @@ export default {
   },
 };
 
-
-// ================================================================
-// GOOGLE SERVICE ACCOUNT AUTHENTICATION
-// ================================================================
-// Generates a short-lived Google OAuth2 access token from service
-// account credentials stored as Worker secrets. Uses RSA-SHA256
-// JWT signing via the Web Crypto API — no external dependencies.
-//
-// Required secrets:
-//   GOOGLE_SERVICE_ACCOUNT_EMAIL — service account email address
-//   GOOGLE_PRIVATE_KEY           — RSA private key from Google
-//                                  Cloud JSON key file
-
-/**
- * Builds a signed JWT and exchanges it for a Google OAuth2 access token.
- *
- * @param {string} email         - Service account email address
- * @param {string} rawPrivateKey - PEM private key (with literal \n sequences)
- * @returns {Promise<string>} A valid OAuth2 access token
- */
-async function getAccessToken(email, rawPrivateKey) {
-
-  // Step 1 — Build the JWT header and payload.
-  const now     = Math.floor(Date.now() / 1000);
-  const header  = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
-  const payload = base64url(JSON.stringify({
-    iss:   email,
-    scope: GOOGLE_AUTH_SCOPE,
-    aud:   'https://oauth2.googleapis.com/token',
-    iat:   now,
-    exp:   now + 3600,
-  }));
-
-  const signingInput = header + '.' + payload;
-
-  // Step 2 — Import the RSA private key via the Web Crypto API.
-  // The key arrives from the secret with literal \n sequences;
-  // convert them to real newlines before stripping the PEM envelope.
-  // Both PKCS#8 and traditional RSA key headers are handled.
-  const pemString = rawPrivateKey.replace(/\\n/g, '\n');
-  const pemBody   = pemString
-    .replace('-----BEGIN PRIVATE KEY-----',     '')
-    .replace('-----END PRIVATE KEY-----',       '')
-    .replace('-----BEGIN RSA PRIVATE KEY-----', '')
-    .replace('-----END RSA PRIVATE KEY-----',   '')
-    .replace(/\n/g, '')
-    .trim();
-
-  const binaryKey = Uint8Array.from(atob(pemBody), c => c.charCodeAt(0));
-
-  const cryptoKey = await crypto.subtle.importKey(
-    'pkcs8',
-    binaryKey,
-    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-    false,
-    ['sign']
-  );
-
-  // Step 3 — Sign the JWT.
-  const signatureBuf = await crypto.subtle.sign(
-    'RSASSA-PKCS1-v1_5',
-    cryptoKey,
-    new TextEncoder().encode(signingInput)
-  );
-
-  const jwt = signingInput + '.' + arrayBufferToBase64url(signatureBuf);
-
-  // Step 4 — Exchange the signed JWT for a short-lived access token.
-  const tokenRes = await fetchWithTimeout('https://oauth2.googleapis.com/token', {
-    method:  'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body:    'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=' + jwt,
-  }, 10000);
-
-  if (!tokenRes.ok) {
-    const errText = await tokenRes.text();
-    throw new Error('Token exchange failed (' + tokenRes.status + '): ' + errText);
-  }
-
-  const tokenData = await tokenRes.json();
-  return tokenData.access_token;
-}
-
-/**
- * Encodes a UTF-8 string to base64url format (used in JWT construction).
- * @param {string} str
- * @returns {string}
- */
-function base64url(str) {
-  return btoa(str)
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=/g,  '');
-}
-
-/**
- * Converts an ArrayBuffer to base64url using a safe byte-by-byte loop.
- * The spread operator can throw a RangeError on large buffers (such as
- * RSA signatures) — this approach avoids that risk entirely.
- * @param {ArrayBuffer} buffer
- * @returns {string}
- */
-function arrayBufferToBase64url(buffer) {
-  const bytes = new Uint8Array(buffer);
-  let binary  = '';
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary)
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=/g,  '');
-}
 
 // ================================================================
 // SHEET DATA FETCHING
@@ -931,7 +809,8 @@ async function runCleanup(env) {
 
   const token       = await getAccessToken(
     env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
-    env.GOOGLE_PRIVATE_KEY
+    env.GOOGLE_PRIVATE_KEY,
+    'https://www.googleapis.com/auth/spreadsheets'
   );
   const now         = new Date();
   const thresholdMs = DELETE_EXPIRED_AFTER_DAYS * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary

- Imports `getAccessToken` from `src/shared/google-auth.js`; removes local copies of `getAccessToken`, `base64url`, and `arrayBufferToBase64url` (~80 lines removed). Both call sites updated (main fetch handler and `runCleanup` scheduled handler) to pass the spreadsheets scope as a literal string third argument.
- Imports `DARK_BG_COLOR` from `src/shared/constants.js`; removes local constant definition.
- Removes local `GOOGLE_AUTH_SCOPE` constant — scope is now passed directly to the shared `getAccessToken` function.

Part of Phase 6 shared-utils migration.

## Test plan

- [ ] Verify `?station=dept` renders department news with no console errors
- [ ] Verify `?station=1` (or any station) renders correctly
- [ ] Verify `?bg=dark` applies the dark background color
- [ ] Confirm scheduled cleanup cron still authenticates and runs without error
- [ ] Confirm no local definitions of `getAccessToken`, `base64url`, `arrayBufferToBase64url`, `DARK_BG_COLOR`, or `GOOGLE_AUTH_SCOPE` remain in `src/index.js`