### PR TITLE
feat: add /healthz endpoint for uptime monitoring

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,6 +146,46 @@ export default {
     }
 
     const url          = new URL(request.url);
+
+    if (url.pathname === '/healthz') {
+      var healthStatus = 'healthy';
+      var healthDetail = '';
+
+      try {
+        var probeRes = await fetchWithTimeout(
+          'https://oauth2.googleapis.com/token',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: 'grant_type=placeholder',
+          },
+          5000
+        );
+        if (probeRes.status === 400) {
+          healthDetail = 'google-apis: reachable';
+        } else {
+          healthStatus = 'degraded';
+          healthDetail = 'google-apis: unexpected status ' + probeRes.status;
+        }
+      } catch (e) {
+        healthStatus = 'degraded';
+        healthDetail = 'google-apis: unreachable (' + (e && e.message ? e.message : String(e)) + ')';
+      }
+
+      return new Response(
+        'status: ' + healthStatus + '\n' +
+        'worker: department-news-display\n' +
+        healthDetail + '\n',
+        {
+          status: healthStatus === 'healthy' ? 200 : 503,
+          headers: {
+            'Content-Type':  'text/plain; charset=UTF-8',
+            'Cache-Control': 'no-store',
+          },
+        }
+      );
+    }
+
     const stationParam = sanitizeParam(url.searchParams.get('station')) || '';
     const layoutParam  = sanitizeParam(url.searchParams.get('layout'))  || 'split';
 


### PR DESCRIPTION
## Summary

- Adds a `/healthz` route as the first check inside the fetch handler
- Probes `oauth2.googleapis.com/token` with a POST; HTTP 400 = reachable = **healthy** (200); network failure or timeout = **degraded** (503)
- Response body is plain text: `status`, `worker`, and a detail line — no JSON, no HTML
- Display pages are completely unchanged

## Test plan

- [ ] `GET /healthz` returns `200` with body `status: healthy\nworker: department-news-display\ngoogle-apis: reachable`
- [ ] Confirm `Cache-Control: no-store` header is present
- [ ] Confirm existing display routes (`?station=dept`, etc.) still work normally
- [ ] Simulate network failure (e.g. block oauth2.googleapis.com) and confirm `503` with `degraded` status is returned

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9iDfgvVe3PNWyo1SxJhSm)_