### PR TITLE
fix: element-based scrolling for iframe compatibility and remove new-item accent border

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -644,7 +644,7 @@ function renderHtml(items, layout, tabName, darkBg) {
                       'border-top:1px solid ' + BORDER_SUBTLE + ';' +
                       'border-right:1px solid ' + BORDER_SUBTLE + ';' +
                       'border-bottom:1px solid ' + BORDER_SUBTLE + ';' +
-                      'border-left:4px solid ' + ACCENT_COLOR + ';' +
+                      'border-left:1px solid ' + BORDER_SUBTLE + ';' +
                       'padding-left:calc(1rem - 3px);';
           titleDivider = '';
           newCount++;
@@ -690,8 +690,10 @@ function renderHtml(items, layout, tabName, darkBg) {
     '  var MIN_SPEED                = ' + MIN_SCROLL_SPEED_PX_PER_SEC + ';' +
     '  var MAX_SPEED                = ' + MAX_SCROLL_SPEED_PX_PER_SEC + ';' +
     '  window.addEventListener("load", function () {' +
-    '    var totalH = document.documentElement.scrollHeight;' +
-    '    var viewH  = window.innerHeight;' +
+    '    var el      = document.getElementById("scroller");' +
+    '    if (!el) return;' +
+    '    var totalH  = el.scrollHeight;' +
+    '    var viewH   = el.clientHeight;' +
     '    if (totalH <= viewH) return;' +
     '    var overflow      = totalH - viewH;' +
     '    var availableTime = Math.max(1, DISPLAY_DURATION_SECONDS - SCROLL_PAUSE_SECONDS);' +
@@ -708,8 +710,8 @@ function renderHtml(items, layout, tabName, darkBg) {
     '        pauseElapsed += delta;' +
     '        if (pauseElapsed >= SCROLL_PAUSE_SECONDS) { scrollStarted = true; }' +
     '      } else {' +
-    '        window.scrollBy(0, speed * delta);' +
-    '        if (window.scrollY + viewH >= totalH) { return; }' +
+    '        el.scrollTop += speed * delta;' +
+    '        if (el.scrollTop + viewH >= totalH) { return; }' +
     '      }' +
     '      requestAnimationFrame(step);' +
     '    }' +
@@ -727,6 +729,11 @@ function renderHtml(items, layout, tabName, darkBg) {
     '  font-size: '   + FONT_SIZE_BODY + ';' +
     '  padding: 0.75rem;' +
     '  overflow-x: hidden;' +
+    '}' +
+
+    '#scroller {' +
+    '  height: 100vh;' +
+    '  overflow: hidden;' +
     '}' +
 
     '.no-news {' +


### PR DESCRIPTION
## Summary

- **Scroll fix:** `window.scrollBy` is unreliable inside iframes — the display system loads all workers as full-screen iframes. Replaced with element-based scrolling on `#scroller` using `scrollTop`. The `#scroller` element now has `height:100vh` and `overflow:hidden` to contain content and prevent the native browser scrollbar from appearing.
- **Accent border removed:** The red left-border on new news items was blending with the column border on the display hardware. The NEW badge already provides a clear visual indicator of new content; border replaced with the same 1px subtle border used on all other sides.

## Changes (`src/index.js`)

- `scrollScript`: `document.getElementById("scroller")` → `el.scrollHeight` / `el.clientHeight` / `el.scrollTop` instead of `window`/`document.documentElement` equivalents
- CSS: added `#scroller { height: 100vh; overflow: hidden; }` after the `body` rule
- New-item `cardStyle`: removed `border-left:4px solid ACCENT_COLOR`, replaced with `border-left:1px solid BORDER_SUBTLE` to match the other three sides

## Test plan

- [ ] Load the display in a full-screen iframe; confirm content scrolls smoothly from top to bottom over the configured duration
- [ ] Confirm no native scrollbar appears during scroll
- [ ] Confirm short pages (content fits in viewport) do not scroll
- [ ] Inspect a new news item card — no red left-border; NEW badge still present
- [ ] Inspect a regular news item card — unchanged styling

Reminder: close issues #29 and #33 once verified on hardware.

https://claude.ai/code/session_018YwtShbnCfnfbb5oS1E3qE

---
_Generated by [Claude Code](https://claude.ai/code/session_018YwtShbnCfnfbb5oS1E3qE)_