### PR TITLE
fix: lock html and body to viewport to prevent native scrollbar

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -721,6 +721,7 @@ function renderHtml(items, layout, tabName, darkBg) {
 
   const css =
     '*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }' +
+    'html { overflow: hidden; }' +
 
     'body {' +
     '  background: ' + (darkBg ? DARK_BG_COLOR : 'transparent') + ';' +
@@ -728,11 +729,12 @@ function renderHtml(items, layout, tabName, darkBg) {
     '  font-family: ' + FONT_STACK + ';' +
     '  font-size: '   + FONT_SIZE_BODY + ';' +
     '  padding: 0.75rem;' +
-    '  overflow-x: hidden;' +
+    '  height: 100vh;' +
+    '  overflow: hidden;' +
     '}' +
 
     '#scroller {' +
-    '  height: 100vh;' +
+    '  height: 100%;' +
     '  overflow: hidden;' +
     '}' +
 


### PR DESCRIPTION
The body had no height constraint, allowing it to grow taller than the viewport and triggering a native browser scrollbar on the html element.

Three CSS changes:
- `html`: `overflow: hidden` so the root element never scrolls
- `body`: `height: 100vh` + `overflow: hidden`, locks to viewport (`box-sizing: border-box` already applied so padding fits within 100vh)
- `#scroller`: `height: 100%` fills the body content area rather than re-measuring `100vh` independently

The element-based scroll script (`scrollTop` on `#scroller`) is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Pm3xtmx6aLJ3QKDZ42NNx)_