### PR TITLE
fix: use setTimeout and clientHeight fallback for reliable scroll init

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -689,11 +689,11 @@ function renderHtml(items, layout, tabName, darkBg) {
     '  var SCROLL_PAUSE_SECONDS     = ' + SCROLL_PAUSE_SECONDS     + ';' +
     '  var MIN_SPEED                = ' + MIN_SCROLL_SPEED_PX_PER_SEC + ';' +
     '  var MAX_SPEED                = ' + MAX_SCROLL_SPEED_PX_PER_SEC + ';' +
-    '  window.addEventListener("load", function () {' +
-    '    var el      = document.getElementById("scroller");' +
+    '  function initScroll() {' +
+    '    var el     = document.getElementById("scroller");' +
     '    if (!el) return;' +
-    '    var totalH  = el.scrollHeight;' +
-    '    var viewH   = el.clientHeight;' +
+    '    var viewH  = el.clientHeight || window.innerHeight;' +
+    '    var totalH = el.scrollHeight;' +
     '    if (totalH <= viewH) return;' +
     '    var overflow      = totalH - viewH;' +
     '    var availableTime = Math.max(1, DISPLAY_DURATION_SECONDS - SCROLL_PAUSE_SECONDS);' +
@@ -716,7 +716,14 @@ function renderHtml(items, layout, tabName, darkBg) {
     '      requestAnimationFrame(step);' +
     '    }' +
     '    requestAnimationFrame(step);' +
-    '  });' +
+    '  }' +
+    '  if (document.readyState === "complete") {' +
+    '    setTimeout(initScroll, 100);' +
+    '  } else {' +
+    '    window.addEventListener("load", function () {' +
+    '      setTimeout(initScroll, 100);' +
+    '    });' +
+    '  }' +
     '}());';
 
   const css =


### PR DESCRIPTION
## Summary

- `el.clientHeight` was returning 0 at load time because `height:100%` depends on the parent's computed height, which may not be finalized when the `load` event fires inside an iframe — causing the scroll guard (`totalH <= viewH`) to short-circuit and skip scrolling entirely.
- Wrapped scroll logic in `initScroll()` and deferred its call with `setTimeout(..., 100)` to give the browser time to finalize layout before measuring element heights.
- Added `el.clientHeight || window.innerHeight` fallback so `viewH` is never 0 even if the element height is not yet computed at measurement time.
- Added `document.readyState === "complete"` check to handle the case where the injected script runs after the load event has already fired.

## Test plan

- [ ] Load a news item whose content overflows the viewport height — confirm it scrolls smoothly after the initial pause.
- [ ] Load a news item whose content fits within the viewport — confirm it does **not** scroll.
- [ ] Verify scroll speed stays within MIN/MAX bounds for both short and long content.
- [ ] Test inside an iframe context (the primary deployment target) to confirm `clientHeight` is non-zero when `initScroll` runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_014esPQs4h1aGKh2maZvtdVZ)_