### PR TITLE
feat: loop scroll animation — pause top, scroll down, pause bottom, repeat

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -702,19 +702,34 @@ function renderHtml(items, layout, tabName, darkBg) {
     '    var speed         = Math.min(MAX_SPEED, Math.max(MIN_SPEED, rawSpeed));' +
     '    var translated    = 0;' +
     '    var pauseElapsed  = 0;' +
-    '    var scrollStarted = false;' +
+    '    var bottomElapsed = 0;' +
+    '    var phase         = "pause-top";' +
     '    var lastTimestamp = null;' +
     '    function step(timestamp) {' +
     '      if (lastTimestamp === null) { lastTimestamp = timestamp; }' +
     '      var delta = (timestamp - lastTimestamp) / 1000;' +
     '      lastTimestamp = timestamp;' +
-    '      if (!scrollStarted) {' +
+    '      if (phase === "pause-top") {' +
     '        pauseElapsed += delta;' +
-    '        if (pauseElapsed >= SCROLL_PAUSE_SECONDS) { scrollStarted = true; }' +
-    '      } else {' +
+    '        if (pauseElapsed >= SCROLL_PAUSE_SECONDS) { phase = "scroll-down"; }' +
+    '      } else if (phase === "scroll-down") {' +
     '        translated += speed * delta;' +
-    '        if (translated >= overflow) { translated = overflow; return; }' +
-    '        inner.style.transform = "translateY(-" + translated + "px)";' +
+    '        if (translated >= overflow) {' +
+    '          translated = overflow;' +
+    '          inner.style.transform = "translateY(-" + translated + "px)";' +
+    '          phase = "pause-bottom";' +
+    '          bottomElapsed = 0;' +
+    '        } else {' +
+    '          inner.style.transform = "translateY(-" + translated + "px)";' +
+    '        }' +
+    '      } else if (phase === "pause-bottom") {' +
+    '        bottomElapsed += delta;' +
+    '        if (bottomElapsed >= SCROLL_PAUSE_SECONDS) {' +
+    '          translated = 0;' +
+    '          inner.style.transform = "translateY(0px)";' +
+    '          pauseElapsed = 0;' +
+    '          phase = "pause-top";' +
+    '        }' +
     '      }' +
     '      requestAnimationFrame(step);' +
     '    }' +


### PR DESCRIPTION
## Summary

- Replaces the one-shot scroll (stops at bottom) with a continuous three-phase loop
- Phase 1 **pause-top**: holds at top for `SCROLL_PAUSE_SECONDS` before starting
- Phase 2 **scroll-down**: animates content upward at the configured speed
- Phase 3 **pause-bottom**: holds at bottom for `SCROLL_PAUSE_SECONDS`, then instantly resets to top and repeats

## Details

Both pauses reuse `SCROLL_PAUSE_SECONDS`. If different durations are ever needed, add a `SCROLL_BOTTOM_PAUSE_SECONDS` constant to the config section and wire it into `pause-bottom`.

The old `scrollStarted` boolean and early `return` (which stopped the rAF loop at the bottom) are replaced by the `phase` state machine, which keeps `requestAnimationFrame` running indefinitely.

## Test plan

- [ ] Verify content longer than the viewport scrolls down smoothly
- [ ] Verify it pauses at the top for ~5 s before scrolling
- [ ] Verify it pauses at the bottom for ~5 s, then snaps back to top
- [ ] Verify the cycle repeats without manual intervention
- [ ] Verify content that fits in the viewport does not scroll (no-op path unchanged)
- [ ] Close issue #29 once verified on hardware

https://claude.ai/code/session_019jNvLaW1gh4PmHcC3xhdDr

---
_Generated by [Claude Code](https://claude.ai/code/session_019jNvLaW1gh4PmHcC3xhdDr)_