### PR TITLE
fix: add 2px buffer to scroll overflow check to prevent false triggers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -695,7 +695,7 @@ function renderHtml(items, layout, tabName, darkBg) {
     '    if (!outer || !inner) return;' +
     '    var viewH  = outer.clientHeight || window.innerHeight;' +
     '    var totalH = inner.offsetHeight;' +
-    '    if (totalH <= viewH) return;' +
+    '    if (totalH <= viewH + 2) return;' +
     '    var overflow      = totalH - viewH;' +
     '    var availableTime = Math.max(1, DISPLAY_DURATION_SECONDS - SCROLL_PAUSE_SECONDS);' +
     '    var rawSpeed      = overflow / availableTime;' +


### PR DESCRIPTION
## Summary

- `inner.offsetHeight` can be marginally larger than `outer.clientHeight` due to sub-pixel rounding or padding/border measurement differences, causing the scroll animation to trigger even when content fits on screen.
- A 2px buffer in the no-overflow guard absorbs this noise: `if (totalH <= viewH + 2) return;`

## Change

**`src/index.js` line 698** — one-line fix in the inline `scrollScript`:

```diff
-    '    if (totalH <= viewH) return;' +
+    '    if (totalH <= viewH + 2) return;' +
```

## Test plan

- [ ] Load a news page where content fits on screen — confirm scroll animation no longer triggers incorrectly
- [ ] Load a news page where content genuinely overflows — confirm scroll animation still triggers and behaves normally
- [ ] Verify `grep -n "totalH <= viewH" src/index.js` returns exactly one match with the `+ 2` buffer

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2dw9TY5wjXDymrrmnrSMW)_