### PR TITLE
fix: accept 2-digit years in parseSheetDateTime

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -529,11 +529,14 @@ function parseSheetDateTime(raw) {
   // technique from calendar-display's parseLocalDateTimeInZone — avoids the
   // bug where new Date("4/18/2026 3:00 PM") is treated as UTC by the
   // Cloudflare Workers runtime (which runs on UTC hosts).
-  var m = s.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})\s+(\d{1,2}):(\d{2})\s*(AM|PM)?$/i);
+  var m = s.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2,4})\s+(\d{1,2}):(\d{2})\s*(AM|PM)?$/i);
   if (m) {
     var mo   = parseInt(m[1], 10);
     var dy   = parseInt(m[2], 10);
     var yr   = parseInt(m[3], 10);
+    // Normalize 2-digit years: 00-49 → 2000-2049, 50-99 → 1950-1999.
+    // This matches the convention used by most spreadsheet applications.
+    if (yr < 100) { yr = yr < 50 ? 2000 + yr : 1900 + yr; }
     var hr   = parseInt(m[4], 10);
     var mn   = parseInt(m[5], 10);
     var ampm = m[6] ? m[6].toUpperCase() : null;


### PR DESCRIPTION
## Summary

- Changed regex in `parseSheetDateTime` from `\d{4}` to `\d{2,4}` so dates like `"4/23/26 7:30 AM"` match the primary parsing path instead of falling through to the UTC fallback.
- Added 2-digit year normalization: 00–49 → 2000–2049, 50–99 → 1950–1999 (matches spreadsheet application conventions).
- 4-digit year entries (e.g. `"4/23/2026 7:30 AM"`) are unaffected.

## Root Cause

2-digit year dates fell through to `new Date()` which the Cloudflare Workers runtime parses as UTC, causing items to expire 5 hours early on CDT (UTC−5).

## Test plan

- [ ] Verify `"4/23/26 7:30 AM"` parses as `2026-04-23T07:30:00` America/Chicago (not UTC)
- [ ] Verify `"4/23/2026 7:30 AM"` still parses correctly (regression check)
- [ ] Verify a 2-digit year ≥ 50 (e.g. `"1/1/99 9:00 AM"`) normalizes to 1999
- [ ] Check news items with 2-digit expiry dates no longer disappear 5 hours early
- [ ] Close issue #34 once verified in staging

## Files Changed

- `src/index.js` — `parseSheetDateTime` only (4 lines: 1 regex change + 3 normalization lines)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vtfg7AwtpF75aqKM3CTnsa)_