### PR TITLE
fix: restore correct variable declaration order in scroll script

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -700,8 +700,9 @@ function renderHtml(items, layout, tabName, darkBg) {
     '    var totalH = inner.offsetHeight;' +
     '    if (totalH <= viewH + 2) return;' +
     '    var overflow      = totalH - viewH;' +
-    '    var rawSpeed      = overflow / availableTime;' +
     '    var availableTime = Math.max(1, DISPLAY_DURATION_SECONDS - (2 * SCROLL_PAUSE_SECONDS));' +
+    '    var rawSpeed      = overflow / availableTime;' +
+    '    var speed         = Math.min(MAX_SPEED, Math.max(MIN_SPEED, rawSpeed));' +
     '    var translated    = 0;' +
     '    var pauseElapsed  = 0;' +
     '    var bottomElapsed = 0;' +


### PR DESCRIPTION
Two bugs introduced during a recent edit to the scroll script:

1. rawSpeed used availableTime before it was declared. JavaScript
   hoists var declarations but not assignments, so availableTime
   was undefined at the point rawSpeed was calculated, producing NaN.

2. The speed variable was lost during a previous edit pass and was
   never declared, causing the animation loop to use undefined speed
   and never advance the translation.

Fixed by reordering declarations and restoring the speed assignment.

---
_Generated by [Claude Code](https://claude.ai/code/session_012gHp9TypnwphFhLP6eRhiK)_