### PR TITLE
fix: cap scroll animation delta to prevent CPU-load jump artifacts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -710,7 +710,7 @@ function renderHtml(items, layout, tabName, darkBg) {
     '    var lastTimestamp = null;' +
     '    function step(timestamp) {' +
     '      if (lastTimestamp === null) { lastTimestamp = timestamp; }' +
-    '      var delta = (timestamp - lastTimestamp) / 1000;' +
+    '      var delta = Math.min((timestamp - lastTimestamp) / 1000, 0.1);' +
     '      lastTimestamp = timestamp;' +
     '      if (phase === "pause-top") {' +
     '        pauseElapsed += delta;' +


### PR DESCRIPTION
On Raspberry Pi hardware without GPU acceleration, requestAnimationFrame
callbacks can be batched when the CPU is under load, delivering multiple
frames worth of elapsed time in a single callback. Without a delta cap,
this caused sudden fast scroll jumps as the translation applied several
hundred milliseconds of movement at once.

Capped delta at 100ms maximum. Under normal conditions (60fps) the
delta is ~16ms and the cap has no effect. Under CPU stress the worst
case jump is now limited to 0.1 * speed pixels instead of potentially
several times that.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoLwoB49BwzyAVSwi3yh29)_