### PR TITLE
fix: prevent scroll animation when no-current-news message is showing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -706,6 +706,7 @@ function renderHtml(items, layout, tabName, darkBg) {
     '    var outer = document.getElementById("scroller");' +
     '    var inner = document.getElementById("scroll-inner");' +
     '    if (!outer || !inner) return;' +
+    '    if (inner.dataset.noScroll) return;' +
     '    var viewH  = outer.clientHeight || window.innerHeight;' +
     '    var totalH = inner.offsetHeight;' +
     '    if (totalH <= viewH + 2) return;' +
@@ -855,7 +856,7 @@ function renderHtml(items, layout, tabName, darkBg) {
     '</head>' +
     '<body>' +
     '<div id="scroller">' +
-    '<div id="scroll-inner">' +
+    '<div id="scroll-inner"' + (items.length === 0 ? ' data-no-scroll="1"' : '') + '>' +
     cardsHtml +
     '</div>' +
     '</div>' +


### PR DESCRIPTION
The no-current-news message has margin-top:3rem which pushed its offsetHeight just above the viewH+2 buffer, causing initScroll to treat it as overflowing content and scroll the message off screen.

Fix: adds `data-no-scroll="1"` to `#scroll-inner` when there are no news items. `initScroll` checks for this attribute and exits immediately before taking any measurements, so the no-news message never scrolls.

## Changes
- `src/index.js` line 858: `#scroll-inner` div now includes `data-no-scroll="1"` when `items.length === 0`
- `src/index.js` line 709: `initScroll` returns early if `inner.dataset.noScroll` is set

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVXLgetfiLSM446TPgmWMk)_