### PR TITLE
fix: retry scroll init when layout measurements return zero

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -702,13 +702,18 @@ function renderHtml(items, layout, tabName, darkBg) {
     '  var SCROLL_PAUSE_SECONDS     = ' + SCROLL_PAUSE_SECONDS     + ';' +
     '  var MIN_SPEED                = ' + MIN_SCROLL_SPEED_PX_PER_SEC + ';' +
     '  var MAX_SPEED                = ' + MAX_SCROLL_SPEED_PX_PER_SEC + ';' +
-    '  function initScroll() {' +
+    '  function initScroll(attempt) {' +
+    '    attempt = attempt || 0;' +
     '    var outer = document.getElementById("scroller");' +
     '    var inner = document.getElementById("scroll-inner");' +
     '    if (!outer || !inner) return;' +
     '    if (inner.dataset.noScroll) return;' +
     '    var viewH  = outer.clientHeight || window.innerHeight;' +
     '    var totalH = inner.offsetHeight;' +
+    '    if ((viewH === 0 || totalH === 0) && attempt < 10) {' +
+    '      setTimeout(function() { initScroll(attempt + 1); }, 100);' +
+    '      return;' +
+    '    }' +
     '    if (totalH <= viewH + 2) return;' +
     '    var overflow      = totalH - viewH;' +
     '    var availableTime = Math.max(1, DISPLAY_DURATION_SECONDS - (2 * SCROLL_PAUSE_SECONDS));' +
@@ -750,10 +755,10 @@ function renderHtml(items, layout, tabName, darkBg) {
     '    requestAnimationFrame(step);' +
     '  }' +
     '  if (document.readyState === "complete") {' +
-    '    setTimeout(initScroll, 100);' +
+    '    setTimeout(initScroll, 500);' +
     '  } else {' +
     '    window.addEventListener("load", function () {' +
-    '      setTimeout(initScroll, 100);' +
+    '      setTimeout(initScroll, 500);' +
     '    });' +
     '  }' +
     '}());';


### PR DESCRIPTION
## Summary

The scroll animation was intermittently failing on Pi hardware because `inner.offsetHeight` returned 0 when layout hadn't finished computing within the initial 100ms delay. When `totalH` is 0, the overflow check (`totalH <= viewH + 2`) always passes and `initScroll` exits silently without scrolling.

## Changes

- **Increased initial delay from 100ms to 500ms** to give Pi hardware more time to complete layout before the first measurement.
- **Added retry logic**: if either `viewH` or `totalH` is 0, retries up to 10 times at 100ms intervals (1 second total) before giving up. This handles variable Pi CPU load across multiple display iframes.

## Test plan

- [ ] Verify scroll animation triggers reliably on Pi hardware after page load
- [ ] Verify scroll still works normally on fast hardware (no regression)
- [ ] Verify content that genuinely does not need scrolling (`totalH <= viewH + 2`) still exits without scrolling
- [ ] Verify the retry counter stops at 10 attempts and does not loop indefinitely

https://claude.ai/code/session_01WSmQiU5wian6bDDF2RhQ2h

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSmQiU5wian6bDDF2RhQ2h)_