### PR TITLE
fix: reload page on visibility change to restart scroll animation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -761,6 +761,11 @@ function renderHtml(items, layout, tabName, darkBg) {
     '      setTimeout(initScroll, 500);' +
     '    });' +
     '  }' +
+    '  document.addEventListener("visibilitychange", function() {' +
+    '    if (document.visibilityState === "visible") {' +
+    '      window.location.reload();' +
+    '    }' +
+    '  });' +
     '}());';
 
   const css =


### PR DESCRIPTION
## Summary

- Adds a `visibilitychange` listener inside the scroll IIFE that calls `window.location.reload()` when `document.visibilityState === "visible"`
- Fixes the case where the Pi display system reuses iframes between cycles rather than reloading them, causing the scroll animation to not restart
- Handler is a no-op if the display system reloads the iframe each cycle (event never fires)

## Details

The Pi display system appears to reuse iframes between display cycles rather than reloading them. When the iframe is hidden, Chromium throttles or pauses `requestAnimationFrame` callbacks. When it becomes visible again, the animation does not reliably restart.

The forced reload ensures the scroll animation always initializes fresh with correct layout measurements on each display cycle.

## Test plan

- [ ] Verify `grep -n "visibilitychange\|visibilityState\|location.reload" src/index.js` returns exactly 3 matches
- [ ] Verify only `src/index.js` was modified (5 insertions, 0 deletions elsewhere)
- [ ] On a test display, hide and re-show the iframe — confirm page reloads and scroll animation restarts correctly
- [ ] Confirm no regression when display system reloads iframe normally (visibility event should not fire)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQYmudV9BsHxCUcaDevjTK)_