### PR TITLE
feat: replace rAF scroll loop with CSS keyframe animation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -714,45 +714,27 @@ function renderHtml(items, layout, tabName, darkBg) {
     '      setTimeout(function() { initScroll(attempt + 1); }, 100);' +
     '      return;' +
     '    }' +
-    '    if (totalH < viewH - 50) return;' +
+    '    if (totalH <= viewH + 2) return;' +
     '    var overflow      = totalH - viewH;' +
     '    var availableTime = Math.max(1, DISPLAY_DURATION_SECONDS - (2 * SCROLL_PAUSE_SECONDS));' +
     '    var rawSpeed      = overflow / availableTime;' +
     '    var speed         = Math.min(MAX_SPEED, Math.max(MIN_SPEED, rawSpeed));' +
-    '    var translated    = 0;' +
-    '    var pauseElapsed  = 0;' +
-    '    var bottomElapsed = 0;' +
-    '    var phase         = "pause-top";' +
-    '    var lastTimestamp = null;' +
-    '    function step(timestamp) {' +
-    '      if (lastTimestamp === null) { lastTimestamp = timestamp; }' +
-    '      var delta = Math.min((timestamp - lastTimestamp) / 1000, 0.1);' +
-    '      lastTimestamp = timestamp;' +
-    '      if (phase === "pause-top") {' +
-    '        pauseElapsed += delta;' +
-    '        if (pauseElapsed >= SCROLL_PAUSE_SECONDS) { phase = "scroll-down"; }' +
-    '      } else if (phase === "scroll-down") {' +
-    '        translated += speed * delta;' +
-    '        if (translated >= overflow) {' +
-    '          translated = overflow;' +
-    '          inner.style.transform = "translateY(-" + translated + "px)";' +
-    '          phase = "pause-bottom";' +
-    '          bottomElapsed = 0;' +
-    '        } else {' +
-    '          inner.style.transform = "translateY(-" + translated + "px)";' +
-    '        }' +
-    '      } else if (phase === "pause-bottom") {' +
-    '        bottomElapsed += delta;' +
-    '        if (bottomElapsed >= SCROLL_PAUSE_SECONDS) {' +
-    '          translated = 0;' +
-    '          inner.style.transform = "translateY(0px)";' +
-    '          pauseElapsed = 0;' +
-    '          phase = "pause-top";' +
-    '        }' +
-    '      }' +
-    '      requestAnimationFrame(step);' +
-    '    }' +
-    '    requestAnimationFrame(step);' +
+    '    var actualScrollTime = overflow / speed;' +
+    '    var totalDuration    = SCROLL_PAUSE_SECONDS + actualScrollTime + SCROLL_PAUSE_SECONDS;' +
+    '    var pauseTopPct      = (SCROLL_PAUSE_SECONDS / totalDuration) * 100;' +
+    '    var pauseBottomPct   = 100 - ((SCROLL_PAUSE_SECONDS / totalDuration) * 100);' +
+    '    var animationName    = "ffd-scroll-" + Date.now();' +
+    '    var keyframes =' +
+    '      "@keyframes " + animationName + " {" +' +
+    '        "0% { transform: translateY(0); }" +' +
+    '        pauseTopPct.toFixed(2) + "% { transform: translateY(0); }" +' +
+    '        pauseBottomPct.toFixed(2) + "% { transform: translateY(-" + overflow + "px); }" +' +
+    '        "100% { transform: translateY(-" + overflow + "px); }" +' +
+    '      "}";' +
+    '    var styleEl = document.createElement("style");' +
+    '    styleEl.textContent = keyframes;' +
+    '    document.head.appendChild(styleEl);' +
+    '    inner.style.animation = animationName + " " + totalDuration + "s linear infinite";' +
     '  }' +
     '  if (document.readyState === "complete") {' +
     '    setTimeout(initScroll, 500);' +
@@ -761,11 +743,6 @@ function renderHtml(items, layout, tabName, darkBg) {
     '      setTimeout(initScroll, 500);' +
     '    });' +
     '  }' +
-    '  document.addEventListener("visibilitychange", function() {' +
-    '    if (document.visibilityState === "visible") {' +
-    '      window.location.reload();' +
-    '    }' +
-    '  });' +
     '}());';
 
   const css =


### PR DESCRIPTION
## Summary

- Replaces the `requestAnimationFrame` scroll loop with a CSS `@keyframes` animation generated once at page load
- JavaScript measures overflow once (with retry logic), injects a unique `@keyframes` rule, then hands off entirely to the browser compositor
- Removes the `visibilitychange` reload listener — no longer needed since CSS animations continue regardless of JS suspend state

## Motivation

The rAF loop ran unreliably on Pi hardware due to CPU contention from other display iframes — callbacks were throttled or dropped, causing scroll animation to stop or never start on subsequent display cycles. CSS animations run on the compositor thread, separate from the main JS thread, making them far more reliable under CPU pressure.

## Behaviors preserved

- `data-no-scroll` attribute prevents the no-news message from scrolling
- 500 ms initial delay + up to 20 retries for layout measurement timing
- Overflow check skips animation when content fits within viewport
- Speed clamped to `MIN_SCROLL_SPEED_PX_PER_SEC` / `MAX_SCROLL_SPEED_PX_PER_SEC`
- Top and bottom pauses match `SCROLL_PAUSE_SECONDS`

## Behaviors changed

- No `requestAnimationFrame` — one-shot measurement, then CSS handles animation
- Animation name uses `Date.now()` so each page load creates a unique keyframes rule
- Animation loops infinitely via `animation-iteration-count: infinite`
- `visibilitychange` listener removed

## Test plan

- [ ] Deploy to a Pi and observe scroll animation across multiple display cycles
- [ ] Verify no-news message does not scroll (data-no-scroll path)
- [ ] Verify short content (fits in viewport) does not animate
- [ ] Verify pause durations at top and bottom match configured `SCROLL_PAUSE_SECONDS`
- [ ] Confirm `requestAnimationFrame` is absent from the built output

---
_Generated by [Claude Code](https://claude.ai/code/session_012SfyyLzM8Y9UZccVfLXCCG)_