### PR TITLE
fix: accept HEAD requests for UptimeRobot health monitoring

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -150,9 +150,13 @@ export default {
    */
   async fetch(request, env) {
 
-    // Reject non-GET requests with a generic status to reduce attack surface.
-    if (request.method !== 'GET') {
-      return new Response('Method not allowed', { status: 405 });
+    // Allow GET and HEAD (HEAD is used by UptimeRobot health monitoring).
+    // All other methods are rejected to reduce attack surface.
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return new Response('Method not allowed', {
+        status: 405,
+        headers: { 'Allow': 'GET, HEAD' },
+      });
     }
 
     const url          = new URL(request.url);
@@ -182,10 +186,12 @@ export default {
         healthDetail = 'google-apis: unreachable (' + (e && e.message ? e.message : String(e)) + ')';
       }
 
-      return new Response(
+      const healthBody =
         'status: ' + healthStatus + '\n' +
         'worker: department-news-display\n' +
-        healthDetail + '\n',
+        healthDetail + '\n';
+      return new Response(
+        request.method === 'HEAD' ? null : healthBody,
         {
           status: healthStatus === 'healthy' ? 200 : 503,
           headers: {


### PR DESCRIPTION
## Summary

- Global method filter now allows both GET and HEAD (was GET-only; HEAD is used by UptimeRobot monitors)
- `/healthz` returns a `null` body for HEAD requests, per HTTP spec
- 405 responses now include an `Allow: GET, HEAD` header

## Details

UptimeRobot HTTP monitors send HEAD requests by default. The global method filter at the top of the fetch handler was rejecting all non-GET requests with 405 before they could reach the `/healthz` route, causing all UptimeRobot health checks to appear as failures.

No change to health check logic or any other routes.

## Test plan

- [ ] Deploy to staging and confirm `curl -I https://<worker>/healthz` returns 200
- [ ] Confirm `curl -X POST https://<worker>/healthz` returns 405 with `Allow: GET, HEAD` header
- [ ] Confirm UptimeRobot monitor shows green after deploy

https://claude.ai/code/session_01XdkGyUy7Q845YfFoHPrDAB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdkGyUy7Q845YfFoHPrDAB)_